### PR TITLE
Add loongarch64 support

### DIFF
--- a/primitive-unaligned.cabal
+++ b/primitive-unaligned.cabal
@@ -22,7 +22,7 @@ library
     , base >=4.12.0.0 && <5
     , primitive >=0.6.4 && < 0.10
   hs-source-dirs: src
-  if arch(aarch64) || arch(alpha) || arch(ia64) || arch(ppc64) || arch(x86_64)
+  if arch(aarch64) || arch(alpha) || arch(ia64) || arch(ppc64) || arch(x86_64) || arch(loongarch64)
     hs-source-dirs: src-64
   if arch(arm) || arch(hppa) || arch(i386) || arch(m68k) || arch(mips) || arch(rs6000) || arch(s390) || arch(sparc) || arch(vax)
     hs-source-dirs: src-32


### PR DESCRIPTION
Hi maintainer,
I have added loongarch64 support in Debian haskell-primitive-unaligned package.
haskell-primitive-unaligned package was built successfully for loongarch64 on Debian Auto-building package system.

Please review.